### PR TITLE
Added toggle to show revoke consent button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,16 @@
+# v0.5.1
+## 06/04/2021
+
+1. [](#Improved)
+    * Add plugin setting to hide Change/Revoke consent button
+
 # v0.5.0
 ##  06/10/2019
 
 1. [](#new)
     * Added plugin settings to let the user deny or allow cookies: compliance_type "opt-in"
 2. [](#improved)
-    * Updated cookie consent js and css from version 3.0.6 to 3.1.1: [cookieconsent.min.css](https://cdn.jsdelivr.net/npm/cookieconsent@3/build/cookieconsent.min.css) and [cookieconsent.min.js](https://cdn.jsdelivr.net/npm/cookieconsent@3/build/cookieconsent.min.js) 
+    * Updated cookie consent js and css from version 3.0.6 to 3.1.1: [cookieconsent.min.css](https://cdn.jsdelivr.net/npm/cookieconsent@3/build/cookieconsent.min.css) and [cookieconsent.min.js](https://cdn.jsdelivr.net/npm/cookieconsent@3/build/cookieconsent.min.js)
 	* Dutch language added
 
 # v0.4.0

--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -1,5 +1,5 @@
 name: Cookie Consent
-version: 0.5.0
+version: 0.5.1
 description: This grav plugin is to alert users about the use of cookies on your website. The plugin integrates the popular js lib cookie consent by insites.
 icon: gavel
 author:
@@ -187,6 +187,17 @@ form:
       placeholder: "Change Cookie Consent"
       validate:
         type: text
+
+    show_revoke:
+      type: toggle
+      label: Show consent button
+      highlight: 1
+      default: 1
+      options:
+        1: Show
+        0: Hide
+      validate:
+        type: bool
 
     callback_onStatusChange:
       type: textarea

--- a/cookieconsent.yaml
+++ b/cookieconsent.yaml
@@ -6,6 +6,7 @@ cdn: true                             # Include JavaScript and CSS files from of
 # content_allow:    # Allow button text (overwrite translation), only used for compliance type opt-in
 # content_deny:     # Deny button text (overwrite translation), only used for compliance type opt-in
 # content_revoke:   # Change/Revoke Consent button text (overwrite translation), only used for compliance type opt-in
+# show_revoke:      # Show the Change/Revoke button, only used for compliance type opt-in
 # content_link:     # Policy link text (overwrite translation)
 # content_href:     # Link to policy (overwrite translation)
 

--- a/languages.yaml
+++ b/languages.yaml
@@ -8,6 +8,7 @@ en:
       CONTENT_LINK: "Learn more"
       CONTENT_HREF: "https://cookiesandyou.com"
       CONTENT_REVOKE: "Change Cookie Consent"
+      SHOW_REVOKE: "Show revoke button"
 
 fr:
   PLUGINS:
@@ -19,6 +20,7 @@ fr:
       CONTENT_LINK: "En savoir plus"
       CONTENT_HREF: "https://cookiesandyou.com"
       CONTENT_REVOKE: "Changer le consentement du cookie"
+      SHOW_REVOKE: "Afficher le bouton de révocation"
 
 de:
   PLUGINS:
@@ -30,6 +32,7 @@ de:
       CONTENT_LINK: "Weitere Informationen"
       CONTENT_HREF: "https://cookiesandyou.com"
       CONTENT_REVOKE: "Cookie-Einstellung ändern"
+      SHOW_REVOKE: "Widerrufsschaltfläche anzeigen"
 
 it:
   PLUGINS:
@@ -41,6 +44,7 @@ it:
       CONTENT_LINK: "scopri di più"
       CONTENT_HREF: "https://cookiesandyou.com"
       CONTENT_REVOKE: "Modifica consenso sui cookie"
+      SHOW_REVOKE: "Mostra pulsante di revoca"
 
 es:
   PLUGINS:
@@ -52,6 +56,7 @@ es:
       CONTENT_LINK: "ver más"
       CONTENT_HREF: "https://cookiesandyou.com"
       CONTENT_REVOKE: "Cambiar consentimiento de cookies"
+      SHOW_REVOKE: "Mostrar botón de revocación"
 
 nl:
   PLUGINS:
@@ -63,3 +68,4 @@ nl:
       CONTENT_LINK: "Lees meer"
       CONTENT_HREF: "https://cookiesandyou.com"
       CONTENT_REVOKE: "Cookie-toestemming wijzigen"
+      SHOW_REVOKE: "Intrekkingsknop weergeven"

--- a/templates/partials/cookieconsent.html.twig
+++ b/templates/partials/cookieconsent.html.twig
@@ -21,8 +21,12 @@ window.cookieconsent.initialise({
 {% if config.plugins.cookieconsent.compliance_type %}
 "type": "{{ config.plugins.cookieconsent.compliance_type }}",
 {% endif %}
-{% if config.plugins.cookieconsent.compliance_type != 'info' %}
-"revokeBtn": '<div class="cc-revoke {{ '{{classes}}' }}">{% if config.plugins.cookieconsent.content_revoke %}{{ config.plugins.cookieconsent.content_revoke }}{% else %}{{ 'PLUGINS.COOKIECONSENT.CONTENT_REVOKE'|t }}{% endif %}</div>',
+{% if config.plugins.cookieconsent.compliance_type != 'info'  %}
+  {% if config.plugins.cookieconsent.show_revoke %}
+    "revokeBtn": '<div class="cc-revoke {{ '{{classes}}' }}">{% if config.plugins.cookieconsent.content_revoke %}{{ config.plugins.cookieconsent.content_revoke }}{% else %}{{ 'PLUGINS.COOKIECONSENT.CONTENT_REVOKE'|t }}{% endif %}</div>',
+  {% else %}
+    "revokeBtn": '<div></div>',
+  {% endif %}
 {% if config.plugins.cookieconsent.callback_onStatusChange %}
 "onStatusChange": {{ config.plugins.cookieconsent.callback_onStatusChange }},
 {% endif %}


### PR DESCRIPTION
Hi @rluetke,

I consider your fork of the plugin to be the only GDPR compliant solution available on Grav right now.

I would rather have a link to revoke/change consent in the footer than this floating button, so I have added an option in the plugin config to hide it. It may be of use to others so here it is!

All the best,
Ari